### PR TITLE
Pass `:system` message when neither `:prompt` nor `:session` is there

### DIFF
--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -205,7 +205,8 @@ This function sends the BODY text to GPTel and returns the response."
                          (ob-gptel-find-prompt prompt system-message)))
                       (session
                        (with-current-buffer buffer
-                         (ob-gptel-find-session session system-message))))
+                         (ob-gptel-find-session session system-message)))
+                      (system-message system-message))
                 :dry-run dry-run
                 :stream nil)))))
     (if dry-run


### PR DESCRIPTION
before:
```
#+begin_src gptel :system "RESPOND IN ALL CAPS" :dry-run yes
tell me a joke
#+end_src

#+RESULTS:
: (:model "llama3.1:latest" :messages [(:role "user" :content "tell me a joke")]
:         :stream :json-false :options (:temperature 1.0))
```

after:
```
#+begin_src gptel :system "RESPOND IN ALL CAPS" :dry-run yes
tell me a joke
#+end_src

#+RESULTS:
: (:model "llama3.1:latest" :messages
:         [(:role "system" :content "RESPOND IN ALL CAPS")
:          (:role "user" :content "tell me a joke")]
:         :stream :json-false :options (:temperature 1.0))

```