### PR TITLE
Use org-babel-insert-result on gptel-request response

### DIFF
--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -151,6 +151,10 @@ This function sends the BODY text to GPTel and returns the response."
          (context (cdr (assoc :context params)))
          (format (cdr (assoc :format params)))
          (dry-run (cdr (assoc :dry-run params)))
+         (result-params (cdr (assoc :result-params params)))
+         (block-marker (copy-marker (save-excursion
+                                      (org-babel-where-is-src-block-head))
+                                    t))
          (buffer (current-buffer))
          (dry-run (and dry-run (not (member dry-run '("no" "nil" "false")))))
          (ob-gptel--uuid (concat "<gptel_thinking_" (org-id-uuid) ">"))
@@ -187,17 +191,12 @@ This function sends the BODY text to GPTel and returns the response."
 					    (save-excursion
 					      (save-restriction
 						(widen)
-						(goto-char (point-min))
-						(when (search-forward ob-gptel--uuid nil t)
-						  (let* ((match-start (match-beginning 0))
-							 (match-end (match-end 0))
-							 (formatted-response
-							  (if (equal format "org")
-							      (gptel--convert-markdown->org (string-trim response))
-							    (string-trim response))))
-						    (goto-char match-start)
-						    (delete-region match-start match-end)
-						    (insert formatted-response))))))))
+						(goto-char block-marker)
+                                                (org-babel-insert-result
+                                                 (if (equal format "org")
+                                                     (gptel--convert-markdown->org (string-trim response))
+                                                   (string-trim response))
+                                                 result-params))))))
 				    :buffer (current-buffer)
 				    :transforms (list #'gptel--transform-apply-preset
 						      (ob-gptel--add-context context))

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -204,6 +204,7 @@ This function sends the BODY text to GPTel and returns the response."
 					   (with-current-buffer buffer
 					     (ob-gptel-find-prompt prompt system-message)))
 					  (session
+					   (goto-char block-start)
 					   (with-current-buffer buffer
 					     (ob-gptel-find-session session system-message))))
 				    :dry-run dry-run

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -152,9 +152,8 @@ This function sends the BODY text to GPTel and returns the response."
          (format (cdr (assoc :format params)))
          (dry-run (cdr (assoc :dry-run params)))
          (result-params (cdr (assoc :result-params params)))
-         (block-marker (copy-marker (save-excursion
-                                      (org-babel-where-is-src-block-head))
-                                    t))
+         (block-start (copy-marker (nth 5 (org-babel-get-src-block-info 'light))
+                                   t))
          (buffer (current-buffer))
          (dry-run (and dry-run (not (member dry-run '("no" "nil" "false")))))
          (ob-gptel--uuid (concat "<gptel_thinking_" (org-id-uuid) ">"))
@@ -191,12 +190,12 @@ This function sends the BODY text to GPTel and returns the response."
 					    (save-excursion
 					      (save-restriction
 						(widen)
-						(goto-char block-marker)
-                                                (org-babel-insert-result
-                                                 (if (equal format "org")
-                                                     (gptel--convert-markdown->org (string-trim response))
-                                                   (string-trim response))
-                                                 result-params))))))
+						(goto-char block-start)
+						(org-babel-insert-result
+						 (if (equal format "org")
+						     (gptel--convert-markdown->org (string-trim response))
+						   (string-trim response))
+						 result-params))))))
 				    :buffer (current-buffer)
 				    :transforms (list #'gptel--transform-apply-preset
 						      (ob-gptel--add-context context))

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -211,7 +211,7 @@ The result is trimmed; returns nil when the region is empty."
         (save-restriction
           (widen)
           (goto-char block-start)
-          (org-babel-insert-result  text result-params))))))
+          (org-babel-insert-result text result-params))))))
 
 (defun ob-gptel--format-response (response format)
   "Trim RESPONSE and convert markdown->org if FORMAT equals \"org\"."
@@ -349,7 +349,7 @@ This function sends the BODY text to GPTel and returns the response."
 				    :callback
 				    (ob-gptel--make-callback
 				      buffer format cell block-start result-params)
-				    :buffer (current-buffer)
+                                    :buffer (current-buffer)
 				    :transforms (list #'gptel--transform-apply-preset
 						      (ob-gptel--add-context context))
 				    :system

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -203,14 +203,14 @@ The result is trimmed; returns nil when the region is empty."
   "Return non-nil when the `pending' library is loadable."
   (featurep 'pending))
 
-(defun ob-gptel--legacy-replace (buffer text block-marker result-params)
+(defun ob-gptel--legacy-replace (buffer text block-start result-params)
   "In BUFFER, find UUID and atomically replace it with TEXT."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (save-excursion
         (save-restriction
           (widen)
-          (goto-char (block-marker))
+          (goto-char block-start)
           (org-babel-insert-result  text result-params))))))
 
 (defun ob-gptel--format-response (response format)
@@ -252,7 +252,7 @@ found."
               (setcar cell token)
               token)))))))
 
-(defun ob-gptel--make-callback (buffer format cell block-marker result-params)
+(defun ob-gptel--make-callback (buffer format cell block-start result-params)
   "Return a gptel callback closure for an async block.
 The callback uses the pending token in (car CELL) when active;
 otherwise it falls back to UUID-based search/replace.
@@ -267,7 +267,7 @@ time."
                    (ob-gptel--use-pending-p)
                    (pending-active-p token))
               (pending-finish token text)
-            (ob-gptel--legacy-replace buffer text block-marker result-params))))
+            (ob-gptel--legacy-replace buffer text block-start result-params))))
        ;; gptel signals abort by calling the callback with the
        ;; symbol `abort'.  Leave the placeholder for `gptel-abort'
        ;; to clean up via the on-cancel path; do nothing here.
@@ -281,7 +281,7 @@ time."
               (pending-reject token (format "%s" reason))
             (ob-gptel--legacy-replace
              buffer
-             (format "(gptel error: %s)" reason) block-marker result-params))))))))
+             (format "(gptel error: %s)" reason) block-start result-params))))))))
 
 (defun org-babel-execute:gptel (body params)
   "Execute a gptel source block with BODY and PARAMS.
@@ -357,6 +357,7 @@ This function sends the BODY text to GPTel and returns the response."
 					   (with-current-buffer buffer
 					     (ob-gptel-find-prompt prompt system-message)))
 					  (session
+					   (goto-char block-start)
 					   (with-current-buffer buffer
 					     (ob-gptel-find-session session system-message))))
 				    :dry-run dry-run

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -299,9 +299,8 @@ This function sends the BODY text to GPTel and returns the response."
          (dry-run (cdr (assoc :dry-run params)))
          (entry (cdr (assoc :entry params)))
          (result-params (cdr (assoc :result-params params)))
-         (block-marker (copy-marker (save-excursion
-                                      (org-babel-where-is-src-block-head))
-                                    t))
+         (block-start (copy-marker (nth 5 (org-babel-get-src-block-info 'light))
+                                   t))
          (buffer (current-buffer))
          (dry-run (and dry-run (not (member dry-run '("no" "nil" "false")))))
          (entry (and entry (not (member entry '("no" "nil" "false")))))
@@ -349,7 +348,7 @@ This function sends the BODY text to GPTel and returns the response."
 				    effective-body
 				    :callback
 				    (ob-gptel--make-callback
-				      buffer format cell block-marker result-params)
+				      buffer format cell block-start result-params)
 				    :buffer (current-buffer)
 				    :transforms (list #'gptel--transform-apply-preset
 						      (ob-gptel--add-context context))

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -203,20 +203,15 @@ The result is trimmed; returns nil when the region is empty."
   "Return non-nil when the `pending' library is loadable."
   (featurep 'pending))
 
-(defun ob-gptel--legacy-replace (uuid buffer text)
+(defun ob-gptel--legacy-replace (buffer text block-marker result-params)
   "In BUFFER, find UUID and atomically replace it with TEXT."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (save-excursion
         (save-restriction
           (widen)
-          (goto-char (point-min))
-          (when (search-forward uuid nil t)
-            (let ((s (match-beginning 0))
-                  (e (match-end 0)))
-              (goto-char s)
-              (delete-region s e)
-              (insert text))))))))
+          (goto-char (block-marker))
+          (org-babel-insert-result  text result-params))))))
 
 (defun ob-gptel--format-response (response format)
   "Trim RESPONSE and convert markdown->org if FORMAT equals \"org\"."
@@ -257,11 +252,12 @@ found."
               (setcar cell token)
               token)))))))
 
-(defun ob-gptel--make-callback (uuid buffer format cell)
+(defun ob-gptel--make-callback (buffer format cell block-marker result-params)
   "Return a gptel callback closure for an async block.
 The callback uses the pending token in (car CELL) when active;
 otherwise it falls back to UUID-based search/replace.
-UUID, BUFFER, and FORMAT are the values captured at request time."
+BUFFER, FORMAT, BLOCK-START and RESULT-PARAMS are the values captured at request
+time."
   (lambda (response info)
     (let ((token (car cell)))
       (cond
@@ -271,7 +267,7 @@ UUID, BUFFER, and FORMAT are the values captured at request time."
                    (ob-gptel--use-pending-p)
                    (pending-active-p token))
               (pending-finish token text)
-            (ob-gptel--legacy-replace uuid buffer text))))
+            (ob-gptel--legacy-replace buffer text block-marker result-params))))
        ;; gptel signals abort by calling the callback with the
        ;; symbol `abort'.  Leave the placeholder for `gptel-abort'
        ;; to clean up via the on-cancel path; do nothing here.
@@ -284,8 +280,8 @@ UUID, BUFFER, and FORMAT are the values captured at request time."
                    (pending-active-p token))
               (pending-reject token (format "%s" reason))
             (ob-gptel--legacy-replace
-             uuid buffer
-             (format "(gptel error: %s)" reason)))))))))
+             buffer
+             (format "(gptel error: %s)" reason) block-marker result-params))))))))
 
 (defun org-babel-execute:gptel (body params)
   "Execute a gptel source block with BODY and PARAMS.
@@ -302,6 +298,10 @@ This function sends the BODY text to GPTel and returns the response."
          (format (cdr (assoc :format params)))
          (dry-run (cdr (assoc :dry-run params)))
          (entry (cdr (assoc :entry params)))
+         (result-params (cdr (assoc :result-params params)))
+         (block-marker (copy-marker (save-excursion
+                                      (org-babel-where-is-src-block-head))
+                                    t))
          (buffer (current-buffer))
          (dry-run (and dry-run (not (member dry-run '("no" "nil" "false")))))
          (entry (and entry (not (member entry '("no" "nil" "false")))))
@@ -349,7 +349,7 @@ This function sends the BODY text to GPTel and returns the response."
 				    effective-body
 				    :callback
 				    (ob-gptel--make-callback
-				     ob-gptel--uuid buffer format cell)
+				      buffer format cell block-marker result-params)
 				    :buffer (current-buffer)
 				    :transforms (list #'gptel--transform-apply-preset
 						      (ob-gptel--add-context context))


### PR DESCRIPTION
I'm using Org 9.8.1 and unlike the examples I see in your README.org, when I execute a source block the asynchronous response from gptel-request escapes the RESULTS block when it is inserted into the buffer.

org-babel-execute:gptel currently doesn't do anything with multiline responses and so it makes sense to me that when the UUID placeholder (which is always a single line) first is inserted by the standard org-babel-insert-result machinery and then replaced by the unpredictable contents that things might get confused.

The outcome of this is that repeated executions of the block accumulate results even with `:results value replace` where only the first line is recognized as part of the RESULTS and is replaced, the rest of the response building up.

```org
#+begin_src gptel
Write a haiku about Emacs Org mode
#+end_src

#+RESULTS:
: Plain text structure,
Plan your life with care and thought,
Org-mode transforms chaos.
```
Executing the block again:

```org
#+begin_src gptel
Write a haiku about Emacs Org mode
#+end_src

#+RESULTS:
: Plain text magic,
Tasks and notes all linked together,
Life organized now.
Plan your life with care and thought,
Org-mode transforms chaos.
```

This PR relies on the standard babel machinery to insert the completed result from gptel-request and handle multi-line output and the range of babel result headers. The UUID placeholder and any previous results will be replaced with `:results replace` and preserved with `:results append` or `:results prepend`.

Now, the full multiline results of executing a source block are captured:

```org
#+begin_src gptel
Write a haiku about Emacs Org mode
#+end_src

#+RESULTS:
: Plain text power flows,
: Headings, tasks, and notes align,
: Life organized with ease.
```
Or, if the response exceeds `org-babel-min-lines-for-block-output` lines:

```org
#+begin_src gptel
Write 3 haikus about Emacs Org mode
#+end_src

#+RESULTS:
#+begin_example
Plain text dreams bloom,
Markdown syntax fades away,
Links bind thought to thought.

,*C-c C-c* strikes,
Tables and trees align now,
Org chart comes alive.

Capture the stream,
Refile tasks into projects,
Life sorted in plain text.
#+end_example
```

I wonder if I've been using it wrong or how others have been dealing with this issue.