### PR TITLE
Use param as system message if no prompt or session

### DIFF
--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -359,7 +359,8 @@ This function sends the BODY text to GPTel and returns the response."
 					     (ob-gptel-find-prompt prompt system-message)))
 					  (session
 					   (with-current-buffer buffer
-					     (ob-gptel-find-session session system-message))))
+					     (ob-gptel-find-session session system-message)))
+					  (t system-message))
 				    :dry-run dry-run
 				    :stream nil)))))
     (if dry-run

--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -207,7 +207,8 @@ This function sends the BODY text to GPTel and returns the response."
 					     (ob-gptel-find-prompt prompt system-message)))
 					  (session
 					   (with-current-buffer buffer
-					     (ob-gptel-find-session session system-message))))
+					     (ob-gptel-find-session session system-message)))
+					  (t system-message))
 				    :dry-run dry-run
 				    :stream nil)))))
     (if dry-run


### PR DESCRIPTION
Currently the `:system` argument to `gptel-request` will be not be set if the block has neither `:prompt` or `:session` parameters present.

This PR will apply the `:system` block parameter in that case.
