### PR TITLE
Add a case to ob-gptel--make-callback to ignore reasoning and tool calls

### DIFF
--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -276,7 +276,9 @@ UUID, BUFFER, and FORMAT are the values captured at request time."
        ;; symbol `abort'.  Leave the placeholder for `gptel-abort'
        ;; to clean up via the on-cancel path; do nothing here.
        ((eq response 'abort) nil)
-       (t
+       ;; gptel returns a nil response when the response is empty
+       ;; or there is an error.
+       ((eq response nil)
         (let ((reason (or (and (listp info) (plist-get info :error))
                           "gptel error")))
           (if (and token


### PR DESCRIPTION
Currently any other response from gptel than a string or 'abort is treated as an error. This results in an error if an LLM performs a tool call or returns its reasoning. In these cases gtpel-request will return a cons cell like (reasoning . text), (tool-call . (...)) or (tool-result . (...)). These get captured by the default route of cond resulting in an error but no error message.

This change only outputs an error if the response is nil, thereby ignoring any reasoning or tool call responses.

This likely solves the error reported by #13 