### PR TITLE
default system prompt for org-babel-execute:gptel 

### DIFF
--- a/ob-gptel.el
+++ b/ob-gptel.el
@@ -354,12 +354,14 @@ This function sends the BODY text to GPTel and returns the response."
 				    :transforms (list #'gptel--transform-apply-preset
 						      (ob-gptel--add-context context))
 				    :system
-				    (cond (prompt
+				    (cond
+                     (prompt
 					   (with-current-buffer buffer
 					     (ob-gptel-find-prompt prompt system-message)))
 					  (session
 					   (with-current-buffer buffer
-					     (ob-gptel-find-session session system-message))))
+					     (ob-gptel-find-session session system-message)))
+                      (t gptel--system-message))
 				    :dry-run dry-run
 				    :stream nil)))))
     (if dry-run


### PR DESCRIPTION
Currently the system prompt in the org-babel-execute:gptel function is set by finding the system prompt in the buffer. If it is not found it passes nil to gptel-request. When the :preset is set and the preset has a :system-message entry this is correctly set to the gptel--system-message variable, but this variable is actively ignored by the gptel-request function when the value of :system-message is set to nil.

This change passes gptel--system-message as the default option.